### PR TITLE
updating listwatch to only get running pods

### DIFF
--- a/pkg/k8s/listwatch.go
+++ b/pkg/k8s/listwatch.go
@@ -15,5 +15,5 @@ const (
 
 // NewListWatch creates a ListWatch for the specified Resource
 func NewListWatch(client *kubernetes.Clientset, resource string) *cache.ListWatch {
-	return cache.NewListWatchFromClient(client.Core().RESTClient(), resource, "", fields.Everything())
+	return cache.NewListWatchFromClient(client.Core().RESTClient(), resource, "", fields.OneTermEqualSelector("status.phase", "Running"))
 }


### PR DESCRIPTION
    This will disable prefetching but would provide better accuracy for cases when there are bunch of pods sitting in completed state.

    There is a short term hack. If were not moving to AWS ProjectedServiceAccountToken, I would have proposed redesigning this thing :): there is no reason to have reverse mapping(ip to pod) in server when it can be done on agent which has more context about the pods on that machine.